### PR TITLE
Prevent tonemapping of scene background texture

### DIFF
--- a/docs/api/en/scenes/Scene.html
+++ b/docs/api/en/scenes/Scene.html
@@ -36,6 +36,13 @@
 		Can be set to a [page:Color] which sets the clear color, a [page:Texture] covering the canvas, a cubemap as a [page:CubeTexture] or an equirectangular as a [page:Texture] . Default is null.
 		</p>
 
+		<h3>[property:Boolean bgToneMapped]</h3>
+		<p>
+		Default is true. Controls if the background respects the renderer's tonemapping setting.
+		If true, the background will be tonemapped as set in the renderer.
+		If false, the background won't be tonemapped no matter what the renderer's tonemapping setting is.
+		</p>
+
 		<h3>[property:Texture environment]</h3>
 		<p>
 		If not null, this texture is set as the environment map for all physical materials in the scene.

--- a/docs/api/zh/scenes/Scene.html
+++ b/docs/api/zh/scenes/Scene.html
@@ -38,6 +38,13 @@
 		或是 a cubemap as a [page:CubeTexture] or an equirectangular as a [page:Texture]。默认值为null。
 		</p>
 
+		<h3>[property:Boolean bgToneMapped]</h3>
+		<p>
+		默认值为true。控制是否对背景应用renderer中设置的tonemap。
+		若该值为true，将对背景应用renderer中设置的tonemap。
+		若该值为false，将无视renderer中的tonemapping设置，不对背景应用tongmap。
+		</p>
+
 		<h3>[property:Texture environment]</h3>
 		<p>
     若该值不为null，则该纹理贴图将会被设为场景中所有物理材质的环境贴图。

--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -18,11 +18,13 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 	let currentBackground = null;
 	let currentBackgroundVersion = 0;
 	let currentTonemapping = null;
+	let currentBgToneMapped = null;
 
 	function render( renderList, scene ) {
 
 		let forceClear = false;
 		let background = scene.isScene === true ? scene.background : null;
+		const bgToneMapped = scene.isScene === true ? scene.bgToneMapped : false;
 
 		if ( background && background.isTexture ) {
 
@@ -101,18 +103,21 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 
 			}
 
+			boxMesh.material.toneMapped = bgToneMapped;
 			boxMesh.material.uniforms.envMap.value = background;
 			boxMesh.material.uniforms.flipEnvMap.value = ( background.isCubeTexture && background.isRenderTargetTexture === false ) ? - 1 : 1;
 
 			if ( currentBackground !== background ||
 				currentBackgroundVersion !== background.version ||
-				currentTonemapping !== renderer.toneMapping ) {
+				currentTonemapping !== renderer.toneMapping ||
+				currentBgToneMapped !== bgToneMapped ) {
 
 				boxMesh.material.needsUpdate = true;
 
 				currentBackground = background;
 				currentBackgroundVersion = background.version;
 				currentTonemapping = renderer.toneMapping;
+				currentBgToneMapped = bgToneMapped;
 
 			}
 
@@ -154,6 +159,7 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 
 			}
 
+			planeMesh.material.toneMapped = bgToneMapped;
 			planeMesh.material.uniforms.t2D.value = background;
 
 			if ( background.matrixAutoUpdate === true ) {
@@ -166,13 +172,15 @@ function WebGLBackground( renderer, cubemaps, state, objects, premultipliedAlpha
 
 			if ( currentBackground !== background ||
 				currentBackgroundVersion !== background.version ||
-				currentTonemapping !== renderer.toneMapping ) {
+				currentTonemapping !== renderer.toneMapping ||
+				currentBgToneMapped !== bgToneMapped ) {
 
 				planeMesh.material.needsUpdate = true;
 
 				currentBackground = background;
 				currentBackgroundVersion = background.version;
 				currentTonemapping = renderer.toneMapping;
+				currentBgToneMapped = bgToneMapped;
 
 			}
 

--- a/src/scenes/Scene.js
+++ b/src/scenes/Scene.js
@@ -8,6 +8,7 @@ class Scene extends Object3D {
 
 		this.type = 'Scene';
 
+		this.bgToneMapped = true;
 		this.background = null;
 		this.environment = null;
 		this.fog = null;
@@ -28,6 +29,7 @@ class Scene extends Object3D {
 
 		super.copy( source, recursive );
 
+		this.bgToneMapped = source.bgToneMapped;
 		if ( source.background !== null ) this.background = source.background.clone();
 		if ( source.environment !== null ) this.environment = source.environment.clone();
 		if ( source.fog !== null ) this.fog = source.fog.clone();
@@ -46,6 +48,7 @@ class Scene extends Object3D {
 		const data = super.toJSON( meta );
 
 		if ( this.fog !== null ) data.object.fog = this.fog.toJSON();
+		data.object.bgToneMapped = this.bgToneMapped.toJSON();
 
 		return data;
 


### PR DESCRIPTION
Cherry-pick #11 

Note: `bgToneMapped` defaults to `false` in #11, now it defaults to `true` to preserve the behaviour in three.js release `r136`.