### PR TITLE
Add allowedExtensions parameter

### DIFF
--- a/src/renderers/WebGLRenderer.js
+++ b/src/renderers/WebGLRenderer.js
@@ -280,7 +280,7 @@ function WebGLRenderer( parameters = {} ) {
 
 	function initGLContext() {
 
-		extensions = new WebGLExtensions( _gl );
+		extensions = new WebGLExtensions( _gl, parameters );
 
 		capabilities = new WebGLCapabilities( _gl, extensions, parameters );
 

--- a/src/renderers/webgl/WebGLExtensions.js
+++ b/src/renderers/webgl/WebGLExtensions.js
@@ -1,6 +1,8 @@
-function WebGLExtensions( gl ) {
+function WebGLExtensions( gl, parameters ) {
 
 	const extensions = {};
+
+	const _allowedExtensions = parameters.allowedExtensions;
 
 	function getExtension( name ) {
 
@@ -12,26 +14,35 @@ function WebGLExtensions( gl ) {
 
 		let extension;
 
-		switch ( name ) {
+		if ( _allowedExtensions !== undefined && _allowedExtensions.indexOf( name ) === - 1 ) {
 
-			case 'WEBGL_depth_texture':
-				extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
-				break;
+			console.warn( 'THREE.WebGLRenderer: Attempt to use extension ' + name + ' which is not allowed.' );
+			extension = null;
 
-			case 'EXT_texture_filter_anisotropic':
-				extension = gl.getExtension( 'EXT_texture_filter_anisotropic' ) || gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' ) || gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
-				break;
+		} else {
 
-			case 'WEBGL_compressed_texture_s3tc':
-				extension = gl.getExtension( 'WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'MOZ_WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_s3tc' );
-				break;
+			switch ( name ) {
 
-			case 'WEBGL_compressed_texture_pvrtc':
-				extension = gl.getExtension( 'WEBGL_compressed_texture_pvrtc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_pvrtc' );
-				break;
+				case 'WEBGL_depth_texture':
+					extension = gl.getExtension( 'WEBGL_depth_texture' ) || gl.getExtension( 'MOZ_WEBGL_depth_texture' ) || gl.getExtension( 'WEBKIT_WEBGL_depth_texture' );
+					break;
 
-			default:
-				extension = gl.getExtension( name );
+				case 'EXT_texture_filter_anisotropic':
+					extension = gl.getExtension( 'EXT_texture_filter_anisotropic' ) || gl.getExtension( 'MOZ_EXT_texture_filter_anisotropic' ) || gl.getExtension( 'WEBKIT_EXT_texture_filter_anisotropic' );
+					break;
+
+				case 'WEBGL_compressed_texture_s3tc':
+					extension = gl.getExtension( 'WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'MOZ_WEBGL_compressed_texture_s3tc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_s3tc' );
+					break;
+
+				case 'WEBGL_compressed_texture_pvrtc':
+					extension = gl.getExtension( 'WEBGL_compressed_texture_pvrtc' ) || gl.getExtension( 'WEBKIT_WEBGL_compressed_texture_pvrtc' );
+					break;
+
+				default:
+					extension = gl.getExtension( name );
+
+			}
 
 		}
 

--- a/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
+++ b/test/unit/src/renderers/webgl/WebGLExtensions.tests.js
@@ -31,7 +31,7 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'Instancing', ( assert ) => {
 
 				const gl = new WebglContextMock();
-				const extensions = new WebGLExtensions( gl );
+				const extensions = new WebGLExtensions( gl, {} );
 				assert.ok( extensions !== undefined );
 
 			} );
@@ -39,7 +39,7 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'has', ( assert ) => {
 
 				const gl = new WebglContextMock( [ 'Extension1', 'Extension2' ] );
-				const extensions = new WebGLExtensions( gl );
+				const extensions = new WebGLExtensions( gl, {} );
 				assert.ok( extensions.has( 'Extension1' ) );
 				assert.ok( extensions.has( 'Extension2' ) );
 				assert.ok( extensions.has( 'Extension1' ) );
@@ -50,7 +50,7 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'has (with aliasses)', ( assert ) => {
 
 				const gl = new WebglContextMock( [ 'WEBKIT_WEBGL_depth_texture' ] );
-				const extensions = new WebGLExtensions( gl );
+				const extensions = new WebGLExtensions( gl, {} );
 				assert.ok( extensions.has( 'WEBGL_depth_texture' ) );
 				assert.ok( extensions.has( 'WEBKIT_WEBGL_depth_texture' ) );
 				assert.notOk( extensions.has( 'EXT_texture_filter_anisotropic' ) );
@@ -61,7 +61,7 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'get', ( assert ) => {
 
 				const gl = new WebglContextMock( [ 'Extension1', 'Extension2' ] );
-				const extensions = new WebGLExtensions( gl );
+				const extensions = new WebGLExtensions( gl, {} );
 				assert.ok( extensions.get( 'Extension1' ) );
 				assert.ok( extensions.get( 'Extension2' ) );
 				assert.ok( extensions.get( 'Extension1' ) );
@@ -72,7 +72,7 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'get (with aliasses)', ( assert ) => {
 
 				const gl = new WebglContextMock( [ 'WEBKIT_WEBGL_depth_texture' ] );
-				const extensions = new WebGLExtensions( gl );
+				const extensions = new WebGLExtensions( gl, {} );
 				assert.ok( extensions.get( 'WEBGL_depth_texture' ) );
 				assert.ok( extensions.get( 'WEBKIT_WEBGL_depth_texture' ) );
 				assert.notOk( extensions.get( 'EXT_texture_filter_anisotropic' ) );
@@ -83,13 +83,22 @@ export default QUnit.module( 'Renderers', () => {
 			QUnit.test( 'init', ( assert ) => {
 
 				const gl = new WebglContextMock();
-				const extensions = new WebGLExtensions( gl );
+				const extensions = new WebGLExtensions( gl, {} );
 				extensions.init( { isWebGL2: false } );
 				assert.ok( extensions );
 				const gl2 = new WebglContextMock();
-				const extensions2 = new WebGLExtensions( gl2 );
+				const extensions2 = new WebGLExtensions( gl2, {} );
 				extensions2.init( { isWebGL2: true } );
 				assert.ok( extensions2 );
+
+			} );
+
+			QUnit.test( 'allowed', ( assert ) => {
+
+				const gl = new WebglContextMock( [ 'AllowedExtension', 'NotAllowedExtension' ] );
+				const extensions = new WebGLExtensions( gl, { allowedExtensions: [ 'AllowedExtension' ] } );
+				assert.ok( extensions.get( 'AllowedExtension' ) );
+				assert.notOk( extensions.get( 'NotAllowedExtension' ) );
 
 			} );
 


### PR DESCRIPTION
Related issue: http://zentao.internal.oppenlab.com:7000/www/index.php?m=bug&f=view&bugID=630

Miniprogram reports supporting `OES_texture_half_float` while the GPU actually doesn't. To work around this, we use a handcrafted extension white list for all the correctly reported extensions.