### PR TITLE
Enable all layer for WebGLBackgrond.

### DIFF
--- a/src/renderers/webgl/WebGLBackground.js
+++ b/src/renderers/webgl/WebGLBackground.js
@@ -98,6 +98,7 @@ function WebGLBackground( renderer, cubemaps, state, objects, alpha, premultipli
 						fog: false
 					} )
 				);
+				boxMesh.layers.enableAll();
 
 				boxMesh.geometry.deleteAttribute( 'normal' );
 				boxMesh.geometry.deleteAttribute( 'uv' );
@@ -161,6 +162,7 @@ function WebGLBackground( renderer, cubemaps, state, objects, alpha, premultipli
 						fog: false
 					} )
 				);
+				planeMesh.layers.enableAll();
 
 				planeMesh.geometry.deleteAttribute( 'normal' );
 


### PR DESCRIPTION
Related issue: http://zentao.internal.oppenlab.com:7000/www/index.php?m=bug&f=view&bugID=632

Before https://github.com/mrdoob/three.js/pull/22426,
when not using array camera, the background doesn't participate
in layer calculation.

We feel the old behaviour is better because we don't need to
always add layer `0` to the camera when doing multipass rendering.

This commit enables all layer for the background.

Note that the behaviour is still slightly different from r115:

When the camera's layer **mask** is set to 0, r115 will render
background and now won't.
