### PR TITLE
Keep the buggy alpha behaviour in r115 when setting compatability flag

### DIFF
--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -64,6 +64,7 @@ class MeshStandardMaterial extends Material {
 		if ( Material.r115Compatible ) {
 
 			this.defines[ 'MULTISCATTERRING_R115_COMPATABILITY' ] = '';
+			this.defines[ 'ALPHA_R115_COMPATABILITY' ] = '';
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/output_fragment.glsl.js
@@ -1,6 +1,8 @@
 export default /* glsl */`
+#ifndef ALPHA_R115_COMPATABILITY
 #ifdef OPAQUE
 diffuseColor.a = 1.0;
+#endif
 #endif
 
 // https://github.com/mrdoob/three.js/pull/22425


### PR DESCRIPTION
Related issue: http://zentao.internal.oppenlab.com:7000/www/index.php?m=bug&f=view&bugID=671
