### PR TITLE
Add a r115 compatible version `perturbNormal2Arb`

### DIFF
--- a/src/materials/MeshMatcapMaterial.js
+++ b/src/materials/MeshMatcapMaterial.js
@@ -37,6 +37,12 @@ class MeshMatcapMaterial extends Material {
 
 		this.defines = { 'MATCAP': '' };
 
+		if ( Material.r115Compatible === true ) {
+
+			this.defines[ 'PERTURB_NORMAL_R115_COMPATABILITY' ] = '';
+
+		}
+
 		this.type = 'MeshMatcapMaterial';
 
 		this.color = new Color( 0xffffff ); // diffuse
@@ -69,7 +75,7 @@ class MeshMatcapMaterial extends Material {
 
 		super.copy( source );
 
-		this.defines = { 'MATCAP': '' };
+		this.defines = source.defines;
 
 		this.color.copy( source.color );
 

--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -65,6 +65,7 @@ class MeshStandardMaterial extends Material {
 
 			this.defines[ 'MULTISCATTERRING_R115_COMPATABILITY' ] = '';
 			this.defines[ 'ALPHA_R115_COMPATABILITY' ] = '';
+			this.defines[ 'PERTURB_NORMAL_R115_COMPATABILITY' ] = '';
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/normalmap_pars_fragment.glsl.js
@@ -32,6 +32,22 @@ export default /* glsl */`
 		vec2 st0 = dFdx( vUv.st );
 		vec2 st1 = dFdy( vUv.st );
 
+	#ifdef PERTURB_NORMAL_R115_COMPATABILITY
+
+		float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
+
+		vec3 S = normalize( ( q0 * st1.t - q1 * st0.t ) * scale );
+		vec3 T = normalize( ( - q0 * st1.s + q1 * st0.s ) * scale );
+		vec3 N = normalize( surf_norm );
+
+		mat3 tsn = mat3( S, T, N );
+
+		mapN.xy *= ( faceDirection * 2.0 - 1.0 );
+
+		return normalize( tsn * mapN );
+
+	#else
+
 		vec3 N = surf_norm; // normalized
 
 		vec3 q1perp = cross( q1, N );
@@ -44,6 +60,8 @@ export default /* glsl */`
 		float scale = ( det == 0.0 ) ? 0.0 : faceDirection * inversesqrt( det );
 
 		return normalize( T * ( mapN.x * scale ) + B * ( mapN.y * scale ) + N * mapN.z );
+
+	#endif
 
 	}
 


### PR DESCRIPTION
Related issue: http://zentao.internal.oppenlab.com:7000/www/index.php?m=bug&f=view&bugID=673

**Description**

`perturbNormal2Arb` was changed in https://github.com/mrdoob/three.js/pull/21299.
