### PR TITLE
Bring back r115 clearcoat implementation

### DIFF
--- a/src/materials/MeshStandardMaterial.js
+++ b/src/materials/MeshStandardMaterial.js
@@ -66,6 +66,7 @@ class MeshStandardMaterial extends Material {
 			this.defines[ 'MULTISCATTERRING_R115_COMPATABILITY' ] = '';
 			this.defines[ 'ALPHA_R115_COMPATABILITY' ] = '';
 			this.defines[ 'PERTURB_NORMAL_R115_COMPATABILITY' ] = '';
+			this.defines[ 'CLEARCOAT_R115_COMPATABILITY' ] = '';
 
 		}
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -24,11 +24,11 @@ struct PhysicalMaterial {
 
 };
 
-// temporary
 #ifndef CLEARCOAT_R115_COMPATABILITY
+// temporary
 vec3 clearcoatSpecular = vec3( 0.0 );
-#endif
 vec3 sheenSpecular = vec3( 0.0 );
+#endif
 
 // This is a curve-fit approxmation to the "Charlie sheen" BRDF integrated over the hemisphere from 
 // Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF". The analysis can be found
@@ -206,12 +206,6 @@ void RE_Direct_Physical(
 
 	#endif
 
-	#ifdef USE_SHEEN
-
-		sheenSpecular += irradiance * BRDF_Sheen( directLight.direction, geometry.viewDir, normal, material.sheenColor, material.sheenRoughness );
-
-	#endif
-
 	#ifdef CLEARCOAT_R115_COMPATABILITY
 
 	float clearcoatInv = 1.0 - clearcoatDHR;
@@ -219,6 +213,22 @@ void RE_Direct_Physical(
 	#else
 
 	float clearcoatInv = 1.0;
+
+	#endif
+
+	#ifdef USE_SHEEN
+
+		vec3 snSpecular = irradiance * BRDF_Sheen( directLight.direction, geometry.viewDir, normal, material.sheenColor, material.sheenRoughness );
+
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+		reflectedLight.directSpecular += clearcoatInv * snSpecular;
+
+	#else
+
+		sheenSpecular += snSpecular;
+
+	#endif
 
 	#endif
 
@@ -280,7 +290,11 @@ void RE_IndirectSpecular_Physical(
 
 	#ifdef USE_SHEEN
 
+	#ifndef CLEARCOAT_R115_COMPATABILITY
+
 		sheenSpecular += irradiance * material.sheenColor * IBLSheenBRDF( normal, geometry.viewDir, material.sheenRoughness );
+
+	#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
+++ b/src/renderers/shaders/ShaderChunk/lights_physical_pars_fragment.glsl.js
@@ -25,7 +25,9 @@ struct PhysicalMaterial {
 };
 
 // temporary
+#ifndef CLEARCOAT_R115_COMPATABILITY
 vec3 clearcoatSpecular = vec3( 0.0 );
+#endif
 vec3 sheenSpecular = vec3( 0.0 );
 
 // This is a curve-fit approxmation to the "Charlie sheen" BRDF integrated over the hemisphere from 
@@ -152,6 +154,13 @@ void computeMultiscattering( const in vec3 normal, const in vec3 viewDir, const 
 
 #endif
 
+#define DEFAULT_SPECULAR_COEFFICIENT 0.04
+
+// Clear coat directional hemishperical reflectance (this approximation should be improved)
+float clearcoatDHRApprox( const in float roughness, const in float dotNL ) {
+	return DEFAULT_SPECULAR_COEFFICIENT + ( 1.0 - DEFAULT_SPECULAR_COEFFICIENT ) * ( pow( 1.0 - dotNL, 5.0 ) * pow( 1.0 - roughness, 2.0 ) );
+}
+
 void RE_Direct_Physical(
 	const in IncidentLight directLight,
 	const in vec3 normal,
@@ -173,7 +182,27 @@ void RE_Direct_Physical(
 
 		vec3 ccIrradiance = dotNLcc * directLight.color;
 
-		clearcoatSpecular += ccIrradiance * BRDF_GGX( directLight.direction, geometry.viewDir, ccNormal, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );
+		vec3 ccSpecular = ccIrradiance * BRDF_GGX( directLight.direction, geometry.viewDir, ccNormal, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );
+
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+		float clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, dotNLcc );
+
+		reflectedLight.directSpecular += material.clearcoat * ccSpecular;
+	
+	#else
+
+		clearcoatSpecular += ccSpecular;
+
+	#endif
+
+	#else
+
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+		float clearcoatDHR = 0.0;
+
+	#endif
 
 	#endif
 
@@ -183,10 +212,20 @@ void RE_Direct_Physical(
 
 	#endif
 
-	reflectedLight.directSpecular += irradiance * BRDF_GGX( directLight.direction, geometry.viewDir, normal, material.specularColor, material.specularF90, material.roughness );
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+	float clearcoatInv = 1.0 - clearcoatDHR;
+
+	#else
+
+	float clearcoatInv = 1.0;
+
+	#endif
+
+	reflectedLight.directSpecular += clearcoatInv * irradiance * BRDF_GGX( directLight.direction, geometry.viewDir, normal, material.specularColor, material.specularF90, material.roughness );
 
 
-	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
+	reflectedLight.directDiffuse += clearcoatInv * irradiance * BRDF_Lambert( material.diffuseColor );
 }
 
 void RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in GeometricContext geometry, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {
@@ -213,13 +252,45 @@ void RE_IndirectSpecular_Physical(
 
 	#ifdef USE_CLEARCOAT
 
-		clearcoatSpecular += clearcoatRadiance * EnvironmentBRDF( ccNormal, geometry.viewDir, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );
+		vec3 ccSpecular = clearcoatRadiance * EnvironmentBRDF( ccNormal, geometry.viewDir, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );
+
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+		float dotNLcc = saturate( dot( ccNormal, geometry.viewDir ) );
+
+		float clearcoatDHR = material.clearcoat * clearcoatDHRApprox( material.clearcoatRoughness, dotNLcc );
+
+		reflectedLight.indirectSpecular += material.clearcoat * ccSpecular;
+	
+	#else
+
+		clearcoatSpecular += ccSpecular;
+
+	#endif
+
+	#else
+
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+		float clearcoatDHR = 0.0;
+
+	#endif
 
 	#endif
 
 	#ifdef USE_SHEEN
 
 		sheenSpecular += irradiance * material.sheenColor * IBLSheenBRDF( normal, geometry.viewDir, material.sheenRoughness );
+
+	#endif
+
+	#ifdef CLEARCOAT_R115_COMPATABILITY
+
+	float clearcoatInv = 1.0 - clearcoatDHR;
+
+	#else
+
+	float clearcoatInv = 1.0;
 
 	#endif
 
@@ -233,7 +304,7 @@ void RE_IndirectSpecular_Physical(
 
 	vec3 diffuse = material.diffuseColor * ( 1.0 - ( singleScattering + multiScattering ) );
 
-	reflectedLight.indirectSpecular += radiance * singleScattering;
+	reflectedLight.indirectSpecular += clearcoatInv * radiance * singleScattering;
 	reflectedLight.indirectSpecular += multiScattering * cosineWeightedIrradiance;
 
 	reflectedLight.indirectDiffuse += diffuse * cosineWeightedIrradiance;

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -190,6 +190,8 @@ void main() {
 
 	#endif
 
+	#ifndef CLEARCOAT_R115_COMPATABILITY
+
 	#ifdef USE_CLEARCOAT
 
 		float dotNVcc = saturate( dot( splitGeoClearcoatNormal, geometry.viewDir ) );
@@ -197,6 +199,8 @@ void main() {
 		vec3 Fcc = F_Schlick( material.clearcoatF0, material.clearcoatF90, dotNVcc );
 
 		outgoingLight = outgoingLight * ( 1.0 - material.clearcoat * Fcc ) + clearcoatSpecular * material.clearcoat;
+
+	#endif
 
 	#endif
 

--- a/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
+++ b/src/renderers/shaders/ShaderLib/meshphysical.glsl.js
@@ -180,6 +180,8 @@ void main() {
 
 	vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;
 
+	#ifndef CLEARCOAT_R115_COMPATABILITY
+
 	#ifdef USE_SHEEN
 
 		// Sheen energy compensation approximation calculation can be found at the end of
@@ -189,8 +191,6 @@ void main() {
 		outgoingLight = outgoingLight * sheenEnergyComp + sheenSpecular;
 
 	#endif
-
-	#ifndef CLEARCOAT_R115_COMPATABILITY
 
 	#ifdef USE_CLEARCOAT
 


### PR DESCRIPTION
Related issue: http://zentao.internal.oppenlab.com:7000/www/index.php?m=bug&f=view&bugID=674

The compatability code is based on the version before https://github.com/mrdoob/three.js/pull/22389.