### PR TITLE
Add platform properties & setProperties

### DIFF
--- a/src/platform.d.ts
+++ b/src/platform.d.ts
@@ -7,6 +7,11 @@ export interface Platform {
   devicePixelRatio(): number;
   fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
   animationContext: AnimationContext;
+  setProperties(properties: PlatformProperties): void;
+}
+
+interface PlatformProperties{
+  rendertargetUseDEPTH_COMPONENT24: boolean;
 }
 
 export declare const platform: Platform;

--- a/src/platform.js
+++ b/src/platform.js
@@ -15,6 +15,12 @@ const platform = {
 		};
 		this.devicePixelRatio = params.devicePixelRatio;
 
+	},
+
+	setProperties( properties ) {
+
+		this.properties = Object.assign( this.properties ?? {}, properties );
+
 	}
 
 };

--- a/src/renderers/WebGLRenderTarget.js
+++ b/src/renderers/WebGLRenderTarget.js
@@ -2,6 +2,7 @@ import { EventDispatcher } from '../core/EventDispatcher.js';
 import { Texture } from '../textures/Texture.js';
 import { LinearFilter } from '../constants.js';
 import { Vector4 } from '../math/Vector4.js';
+import { platform } from '../platform.js';
 
 /*
  In options, we can specify:
@@ -35,6 +36,13 @@ class WebGLRenderTarget extends EventDispatcher {
 		this.depthBuffer = options.depthBuffer !== undefined ? options.depthBuffer : true;
 		this.stencilBuffer = options.stencilBuffer !== undefined ? options.stencilBuffer : false;
 		this.depthTexture = options.depthTexture !== undefined ? options.depthTexture : null;
+
+		/**
+		 * ios16.4.1 gl.DEPTH_COMPONENT16 does not work well in rendertarget
+		 * it only works in depthBuffer true & stencilBuffer false & depthTexture null
+		 * see WebGlTextures.setupRenderBufferStorage
+		 * */
+		this.useDEPTH_COMPONENT24 = platform.properties?.rendertargetUseDEPTH_COMPONENT24;
 
 	}
 

--- a/src/renderers/webgl/WebGLTextures.js
+++ b/src/renderers/webgl/WebGLTextures.js
@@ -1126,7 +1126,7 @@ function WebGLTextures( _gl, extensions, state, properties, capabilities, utils,
 
 		if ( renderTarget.depthBuffer && ! renderTarget.stencilBuffer ) {
 
-			let glInternalFormat = _gl.DEPTH_COMPONENT16;
+			let glInternalFormat = renderTarget.useDEPTH_COMPONENT24 ? _gl.DEPTH_COMPONENT24 : _gl.DEPTH_COMPONENT16;
 
 			if ( isMultisample || renderTarget.useRenderToTexture ) {
 


### PR DESCRIPTION
  * properties add rendertargetUseDEPTH_COMPONENT24

**Description**

Ios16.4.1, gl.DEPTH_COMPONENT16 does not work well in rendertarget.
It only works in depthBuffer true & stencilBuffer false & depthTexture null

