### PR TITLE
package json exports typing resolve

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./build/three.module.js",
-      "require": "./build/three.cjs"
+      "require": "./build/three.cjs",
+      "types": "./index.d.ts"
     },
     "./examples/fonts/*": "./examples/fonts/*",
     "./examples/jsm/*": "./examples/jsm/*",


### PR DESCRIPTION
Related issue: ts import no typing

**Description**

 does not automatically recognize index.d.ts. It says there's a conflict with package-json.exports

Add exports - . -types and point to index.d.ts
