### PR TITLE
spport node.uniqueName in Animation binding

### DIFF
--- a/src/animation/PropertyBinding.js
+++ b/src/animation/PropertyBinding.js
@@ -195,7 +195,7 @@ class PropertyBinding {
 
 	static findNode( root, nodeName ) {
 
-		if ( ! nodeName || nodeName === '' || nodeName === '.' || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid ) {
+		if ( ! nodeName || nodeName === '' || nodeName === '.' || nodeName === - 1 || nodeName === root.name || nodeName === root.uuid || nodeName === root.uniqueName ) {
 
 			return root;
 
@@ -223,7 +223,7 @@ class PropertyBinding {
 
 					const childNode = children[ i ];
 
-					if ( childNode.name === nodeName || childNode.uuid === nodeName ) {
+					if ( childNode.name === nodeName || childNode.uuid === nodeName || childNode.uniqueName === nodeName ) {
 
 						return childNode;
 


### PR DESCRIPTION
Related issue: https://its.internal.oppenlab.com/view.php?id=218

Support the use of node.uniqueName, which is automatically generated by Oppen's GLTFLoader when there's a duplicate in names.

Changes animation/PropertyBinding.js. It also tries to mach node with the uniqueName on it.

